### PR TITLE
首页改版：合并主按钮、记录继续阅读并优化侧栏与暗色样式

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,9 +48,15 @@ const config = {
             type: 'docSidebar',
             sidebarId: 'docsSidebar',
             position: 'left',
-            label: '按卷书阅读',
+            label: '按卷书阅读神的话语',
           },
         ],
+      },
+      docs: {
+        sidebar: {
+          hideable: true,
+          autoCollapseCategories: true,
+        },
       },
       footer: {
         style: 'light',

--- a/public/img/home-hero.svg
+++ b/public/img/home-hero.svg
@@ -1,0 +1,17 @@
+<svg width="1600" height="700" viewBox="0 0 1600 700" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#374151" />
+      <stop offset="55%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+    <linearGradient id="light" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="700" fill="url(#bg)" />
+  <circle cx="300" cy="120" r="240" fill="url(#light)" />
+  <circle cx="1250" cy="80" r="180" fill="url(#light)" />
+  <path d="M0 560C180 520 280 480 460 500C640 520 760 640 960 640C1160 640 1280 560 1600 480V700H0V560Z" fill="#111827" fill-opacity="0.6" />
+</svg>

--- a/sidebars.js
+++ b/sidebars.js
@@ -3,6 +3,7 @@ module.exports = {
     {
       "type": "category",
       "label": "旧约",
+      "collapsed": true,
       "items": [
         {
           "type": "category",
@@ -282,6 +283,7 @@ module.exports = {
     {
       "type": "category",
       "label": "新约",
+      "collapsed": true,
       "items": [
         {
           "type": "category",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -12,3 +12,156 @@
 main {
   background: #faf9f6;
 }
+
+.homeLayout {
+  background: #faf9f6;
+  color: #1f2937;
+}
+
+.homeHero {
+  position: relative;
+  min-height: 420px;
+  padding: 2.5rem 1.5rem 3rem;
+  background-image: url('/img/home-hero.svg');
+  background-size: cover;
+  background-position: center;
+  color: #f8fafc;
+}
+
+.homeHeroContent {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.homeHeroTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.homeBackButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(248, 250, 252, 0.5);
+  color: #f8fafc;
+  font-size: 0.85rem;
+  text-decoration: none;
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.homeHeroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.homePrimaryButton {
+  background: #d9f99d;
+  color: #1f2937;
+  border: none;
+}
+
+.homeSecondaryButton {
+  background: rgba(248, 250, 252, 0.15);
+  border: 1px solid rgba(248, 250, 252, 0.6);
+  color: #f8fafc;
+}
+
+.homeSection {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.homeSection h2 {
+  margin-bottom: 1.5rem;
+  font-size: 1.5rem;
+}
+
+.homeCardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.homeCard {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.homeCardMeta {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.homeResourceStrip {
+  background: #f1f5f9;
+  border-radius: 18px;
+  padding: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  align-items: center;
+}
+
+.homeResourceItem {
+  background: #ffffff;
+  border-radius: 14px;
+  padding: 1.25rem;
+  min-height: 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.homeAbout {
+  background: #111827;
+  color: #e5e7eb;
+  padding: 3rem 1.5rem;
+}
+
+.homeAboutInner {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+html[data-theme='dark'] main,
+html[data-theme='dark'] .homeLayout {
+  background: #0b0f1a;
+  color: #e5e7eb;
+}
+
+html[data-theme='dark'] .homeCard {
+  background: #111827;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+html[data-theme='dark'] .homeCardMeta {
+  color: #9ca3af;
+}
+
+html[data-theme='dark'] .homeResourceStrip {
+  background: #111827;
+}
+
+html[data-theme='dark'] .homeResourceItem {
+  background: #0f172a;
+}
+
+html[data-theme='dark'] .homeAbout {
+  background: #0b0f1a;
+}

--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -1,0 +1,27 @@
+import React, {useEffect} from 'react';
+import Layout from '@theme/Layout';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+export default function DocsIndex() {
+  const defaultDocPath = useBaseUrl('/docs/old-testament/创世记/introduction');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const savedPath = window.localStorage.getItem('lastReadDocPath');
+    if (savedPath) {
+      window.location.replace(savedPath);
+      return;
+    }
+    window.location.replace(defaultDocPath);
+  }, [defaultDocPath]);
+
+  return (
+    <Layout title="正在跳转">
+      <main style={{padding: '4rem 1.5rem', textAlign: 'center'}}>
+        正在跳转到上次阅读的位置…
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,25 +1,122 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 
 export default function Home() {
+  const [lastRead, setLastRead] = useState(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const savedPath = window.localStorage.getItem('lastReadDocPath');
+    const savedTitle = window.localStorage.getItem('lastReadDocTitle');
+    if (savedPath) {
+      setLastRead({
+        path: savedPath,
+        title: savedTitle || '继续上次阅读',
+      });
+    }
+  }, []);
+
+  const articles = [
+    {
+      title: '在信心中持续前行',
+      excerpt: '从创世记到启示录，我们一步步学习信心的脚踪与盼望。',
+      meta: '更新于最近一次讲道',
+    },
+    {
+      title: '旧约中的恩典线索',
+      excerpt: '透过律法、历史与诗歌，看到神持守的救赎计划。',
+      meta: '旧约专题',
+    },
+    {
+      title: '福音光照日常',
+      excerpt: '灵修分享帮助我们在日常中操练祷告与顺服。',
+      meta: '灵修分享',
+    },
+  ];
+
+  const resources = [
+    {
+      title: '讲道资源',
+      description: '整理主日讲道与专题系列，按主题浏览。',
+    },
+    {
+      title: '阅读计划',
+      description: '按卷书阅读路径，帮助系统性阅读。',
+    },
+    {
+      title: '音频与讲义',
+      description: '收听与下载内容，随时继续学习。',
+    },
+  ];
+
   return (
     <Layout title="圣经讲道与灵修分享" description="按卷书系统性分享神的话语与教会讲道">
-      <main style={{ padding: '4rem 1.5rem', maxWidth: '960px', margin: '0 auto' }}>
-        <h1 style={{ fontWeight: 600, marginBottom: '1rem' }}>圣经讲道与灵修分享</h1>
-        <p style={{ lineHeight: 1.9, color: '#3a3a3a' }}>
-          在这安静的空间里，我们按圣经卷书系统性地分享神的话语与教会讲道，
-          盼望每一次阅读都成为敬拜与生命更新的起点。
-        </p>
-        <p style={{ lineHeight: 1.9, color: '#3a3a3a' }}>
-          请从旧约或新约开始，按卷书缓缓前行，让经文引导你看见主的信实与恩典。
-        </p>
-        <Link
-          className="button button--primary"
-          to="/docs/old-testament/创世记/introduction"
-        >
-          从创世记开始阅读
-        </Link>
+      <main className="homeLayout">
+        <section className="homeHero">
+          <div className="homeHeroContent">
+            <div className="homeHeroTop">
+              <Link className="homeBackButton" to="/">
+                回到主页
+              </Link>
+              <span>按卷书阅读神的话语</span>
+            </div>
+            <div>
+              <h1>圣经讲道与灵修分享</h1>
+              <p>
+                按卷书系统性分享神的话语与教会讲道，让每一次阅读成为敬拜与生命更新的起点。
+              </p>
+            </div>
+            <div className="homeHeroActions">
+              <Link className="button homePrimaryButton" to="/docs">
+                按卷书阅读神的话语
+              </Link>
+              {lastRead && (
+                <Link className="button homeSecondaryButton" to={lastRead.path}>
+                  继续上次阅读 · {lastRead.title}
+                </Link>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="homeSection">
+          <h2>文章</h2>
+          <div className="homeCardGrid">
+            {articles.map((article) => (
+              <div className="homeCard" key={article.title}>
+                <strong>{article.title}</strong>
+                <span className="homeCardMeta">{article.meta}</span>
+                <p>{article.excerpt}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="homeSection">
+          <h2>资源</h2>
+          <div className="homeResourceStrip">
+            {resources.map((resource) => (
+              <div className="homeResourceItem" key={resource.title}>
+                <strong>{resource.title}</strong>
+                <p>{resource.description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="homeAbout">
+          <div className="homeAboutInner">
+            <h2>关于我们</h2>
+            <p>
+              我们致力于以圣经为中心的讲道与灵修分享，盼望帮助弟兄姊妹在真道上扎根，
+              在生活中经历主的恩典。
+            </p>
+            <p>如需联系或获取更多资源，请访问各卷书内容或相关资料区。</p>
+          </div>
+        </section>
       </main>
     </Layout>
   );

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -1,0 +1,24 @@
+import React, {useEffect} from 'react';
+import DocItem from '@theme-original/DocItem';
+import {useDoc} from '@docusaurus/theme-common/internal';
+import {useLocation} from '@docusaurus/router';
+
+export default function DocItemWrapper(props) {
+  const {metadata} = useDoc();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const path = metadata?.permalink || location.pathname;
+    if (path) {
+      window.localStorage.setItem('lastReadDocPath', path);
+    }
+    if (metadata?.title) {
+      window.localStorage.setItem('lastReadDocTitle', metadata.title);
+    }
+  }, [metadata?.permalink, metadata?.title, location.pathname]);
+
+  return <DocItem {...props} />;
+}


### PR DESCRIPTION
### Motivation
- 合并首页重复的“按卷书阅读”按钮为一个更明确的入口，并在首页提供“继续上次阅读”功能以提升阅读连续性。 
- 记录用户最近阅读位置并在访问 `/docs` 时自动跳转到上次位置，减少查找成本。 
- 改善“关灯/暗色”视觉体验，使暗黑模式下页面显示一致且可读。 
- 优化侧边栏折叠与展开行为，靠近用户期待的折叠/展开体验（类似 IDE 的折叠效果）。

### Description
- 重做首页版式并合并主按钮：新增 `src/pages/index.js` 与样式 `src/css/custom.css`，将主入口改为“按卷书阅读神的话语”，并按图示风格添加 hero、文章、资源、关于我们区块。 (新增资源：`public/img/home-hero.svg`) 
- 实现继续上次阅读：新增 `src/theme/DocItem/index.js` 在每个文档渲染时将 `permalink` 与 `title` 写入 `localStorage`，并新增 `src/pages/docs/index.js`，访问 `/docs` 时读取并跳转到 `lastReadDocPath`（若无则跳转默认卷书）。
- 侧边栏与导航调整：将导航标签改为 `按卷书阅读神的话语`，在 `docusaurus.config.js` 中启用 `docs.sidebar.hideable` 与 `autoCollapseCategories`，并在 `sidebars.js` 为顶级“旧约/新约”设置初始 `collapsed: true`。 
- 暗色/关灯样式改善：在 `src/css/custom.css` 添加对 `html[data-theme='dark']` 的覆盖，调整卡片、资源条与关于区颜色以在暗色模式下正确显示。 

### Testing
- 尝试运行本地开发服务器：执行 `npm run start -- --host 0.0.0.0 --port 3000`，启动失败并报错，原因是 `docusaurus.config.js` 中 `url` 仍为占位符 `https://<GITHUB_USERNAME>.github.io` 导致配置校验失败。 
- 除上述启动尝试外，未运行其他自动化测试；功能变更已通过代码检查与本地静态文件添加确认（文件已提交）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a3cf4b508323a1971e76a9d3ce6b)