### PR TITLE
修复首页 hero 背景图路径解析错误

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -22,7 +22,7 @@ main {
   position: relative;
   min-height: 420px;
   padding: 2.5rem 1.5rem 3rem;
-  background-image: url('/img/home-hero.svg');
+  background-image: url('../../public/img/home-hero.svg');
   background-size: cover;
   background-position: center;
   color: #f8fafc;


### PR DESCRIPTION
### Motivation

- 修复构建时 `css-loader` 无法解析 `'/img/home-hero.svg'` 导致的构建失败。
- 原来的绝对路径在构建环境中未指向可解析的资源位置。
- 需要将样式中对静态资源的引用调整为与构建输出目录匹配的相对路径。

### Description

- 将 `src/css/custom.css` 中 `.homeHero` 的 `background-image` 从 `'/img/home-hero.svg'` 改为 `'../../public/img/home-hero.svg'`。
- 只修改并提交了 `src/css/custom.css` 这一处样式引用。 

### Testing

- 未运行任何自动化测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a6a73ca48323ba58ab9aa97269d5)