### PR TITLE
修复 DocItem 中 `useDoc` 导入来源

### DIFF
--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -1,6 +1,6 @@
 import React, {useEffect} from 'react';
 import DocItem from '@theme-original/DocItem';
-import {useDoc} from '@docusaurus/theme-common/internal';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
 import {useLocation} from '@docusaurus/router';
 
 export default function DocItemWrapper(props) {


### PR DESCRIPTION
### Motivation
- 页面在点击“按卷书阅读神的话语”按钮时崩溃，报错为 `(0 , _docusaurus_theme_common_internal__WEBPACK_IMPORTED_MODULE_2__.useDoc) is not a function`。
- 问题原因是从不受支持的位置导入 `useDoc` 钩子导致钩子不可用。
- 目标是改用 Docusaurus 推荐的钩子导入以恢复文档页面的正常渲染。

### Description
- 在 `src/theme/DocItem/index.js` 中将 `useDoc` 的导入由 `@docusaurus/theme-common/internal` 改为 `@docusaurus/plugin-content-docs/client`。
- 保持组件内部保存 `metadata.permalink` 与 `metadata.title` 到 `localStorage` 的现有逻辑不变。

### Testing
- 未运行任何自动化测试（未请求或执行构建/测试命令）。
- 代码已修改并提交，但没有执行 `npm run build` 或其他自动化验证步骤。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a7d2be8083239f74b64f71cbe385)