### PR TITLE
修复 DocItem 包装组件在 DocProvider 外调用 `useDoc` 导致崩溃

### DIFF
--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -1,10 +1,9 @@
 import React, {useEffect} from 'react';
 import DocItem from '@theme-original/DocItem';
-import {useDoc} from '@docusaurus/plugin-content-docs/client';
 import {useLocation} from '@docusaurus/router';
 
 export default function DocItemWrapper(props) {
-  const {metadata} = useDoc();
+  const metadata = props?.content?.metadata;
   const location = useLocation();
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- 修复页面在点击文档时出现的崩溃错误：`Hook useDoc is called outside the <DocProvider>`。
- 避免在组件挂载阶段调用会依赖上下文的 hook，从而支持在没有 `DocProvider` 包裹的情况下安全渲染。
- 保持记录最后阅读文档路径和标题的功能以便继续写入本地存储。
- 降低服务端渲染或定制主题替换时出现的运行时错误风险。

### Description
- 在 `src/theme/DocItem/index.js` 中移除了对 `useDoc` 的调用并删除了相应的导入。  
- 改为直接从 `props.content.metadata` 读取文档元数据（使用 `props?.content?.metadata`）。  
- 保留原有的 `useEffect` 行为以将路径写入 `localStorage` 的键 `lastReadDocPath` 和 `lastReadDocTitle`。  
- 变更减少了对 `DocProvider` 上下文的依赖，从而避免在外部调用 hook 导致的崩溃。

### Testing
- 没有运行任何自动化测试。  
- 已在本地修改并提交了 `src/theme/DocItem/index.js`，更改已编译通过（无自动化测试执行结果）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a891191483238a79ae62474bc1d6)