### PR TITLE
更新首页布局：展示最近三篇讲道卡片并移除资源条

### DIFF
--- a/docs/new-testament/约翰福音/introduction.md
+++ b/docs/new-testament/约翰福音/introduction.md
@@ -1,5 +1,10 @@
 ---
 title: 卷书简介
+sermonTitle: 耶稣如何成为世界的光？
+scripture: 约翰福音 1:1-14
+summary: 在道成肉身的光中，我们看见父的荣耀，也被呼召在黑暗中活出见证与盼望。
+cover: /img/sermon-grace.svg
+updated: 2025-02-24
 ---
 
 **经文摘录：**

--- a/docs/new-testament/罗马书/introduction.md
+++ b/docs/new-testament/罗马书/introduction.md
@@ -1,5 +1,10 @@
 ---
 title: 卷书简介
+sermonTitle: 因信称义的恩典之路
+scripture: 罗马书 5:1-5
+summary: 因信进入神所赐的和平，学习在患难中持守盼望，让恩典塑造我们的生命节奏。
+cover: /img/sermon-hope.svg
+updated: 2025-02-18
 ---
 
 **经文摘录：**

--- a/docs/old-testament/创世记/introduction.md
+++ b/docs/old-testament/创世记/introduction.md
@@ -1,5 +1,10 @@
 ---
 title: 卷书简介
+sermonTitle: 起初的呼召
+scripture: 创世记 1:1-5
+summary: 当我们回到起初，重新聆听神创造与拣选的呼召，学习在日常中以信心回应祂的带领。
+cover: /img/sermon-light.svg
+updated: 2025-03-01
 ---
 
 **经文摘录：**

--- a/public/img/sermon-grace.svg
+++ b/public/img/sermon-grace.svg
@@ -1,0 +1,16 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grace" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#e0f2fe"/>
+      <stop offset="55%" stop-color="#93c5fd"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="river" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#bfdbfe"/>
+      <stop offset="100%" stop-color="#38bdf8"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" fill="url(#grace)"/>
+  <path d="M0 260C120 220 220 230 320 250C420 270 520 300 640 280V360H0V260Z" fill="url(#river)"/>
+  <circle cx="130" cy="90" r="70" fill="rgba(255,255,255,0.35)"/>
+</svg>

--- a/public/img/sermon-hope.svg
+++ b/public/img/sermon-hope.svg
@@ -1,0 +1,16 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="hope" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ede9fe"/>
+      <stop offset="55%" stop-color="#c4b5fd"/>
+      <stop offset="100%" stop-color="#8b5cf6"/>
+    </linearGradient>
+    <linearGradient id="hill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#d1fae5"/>
+      <stop offset="100%" stop-color="#10b981"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" fill="url(#hope)"/>
+  <path d="M0 250C140 210 250 220 360 240C470 260 560 280 640 260V360H0V250Z" fill="url(#hill)"/>
+  <circle cx="520" cy="90" r="80" fill="rgba(255,255,255,0.35)"/>
+</svg>

--- a/public/img/sermon-light.svg
+++ b/public/img/sermon-light.svg
@@ -1,0 +1,16 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="sunrise" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fef3c7"/>
+      <stop offset="45%" stop-color="#fde68a"/>
+      <stop offset="100%" stop-color="#f59e0b"/>
+    </linearGradient>
+    <linearGradient id="meadow" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#dcfce7"/>
+      <stop offset="100%" stop-color="#16a34a"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" fill="url(#sunrise)"/>
+  <circle cx="460" cy="100" r="110" fill="rgba(255,255,255,0.4)"/>
+  <path d="M0 240C120 200 220 210 320 230C420 250 520 270 640 240V360H0V240Z" fill="url(#meadow)"/>
+</svg>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,25 +36,6 @@ main {
   gap: 1.5rem;
 }
 
-.homeHeroTop {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.homeBackButton {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.4rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid rgba(248, 250, 252, 0.5);
-  color: #f8fafc;
-  font-size: 0.85rem;
-  text-decoration: none;
-  background: rgba(15, 23, 42, 0.35);
-}
-
 .homeHeroActions {
   display: flex;
   flex-wrap: wrap;
@@ -65,12 +46,6 @@ main {
   background: #d9f99d;
   color: #1f2937;
   border: none;
-}
-
-.homeSecondaryButton {
-  background: rgba(248, 250, 252, 0.15);
-  border: 1px solid rgba(248, 250, 252, 0.6);
-  color: #f8fafc;
 }
 
 .homeSection {
@@ -93,37 +68,45 @@ main {
 .homeCard {
   background: #ffffff;
   border-radius: 16px;
-  padding: 1.5rem;
+  padding: 1.25rem;
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-}
-
-.homeCardMeta {
-  font-size: 0.85rem;
-  color: #6b7280;
-}
-
-.homeResourceStrip {
-  background: #f1f5f9;
-  border-radius: 18px;
-  padding: 1.5rem;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
-  align-items: center;
 }
 
-.homeResourceItem {
-  background: #ffffff;
-  border-radius: 14px;
-  padding: 1.25rem;
-  min-height: 120px;
+.homeCardLink {
+  color: inherit;
+  text-decoration: none;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  justify-content: center;
+  gap: 0.75rem;
+  height: 100%;
+}
+
+.homeCardImage {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.homeCardScripture {
+  font-size: 0.85rem;
+  color: #9ca3af;
+  letter-spacing: 0.02em;
+}
+
+.homeCardTitle {
+  font-size: 1.1rem;
+  margin: 0;
+  color: #111827;
+}
+
+.homeCardDescription {
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.6;
 }
 
 .homeAbout {
@@ -150,16 +133,16 @@ html[data-theme='dark'] .homeCard {
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
 }
 
-html[data-theme='dark'] .homeCardMeta {
-  color: #9ca3af;
+html[data-theme='dark'] .homeCardTitle {
+  color: #f8fafc;
 }
 
-html[data-theme='dark'] .homeResourceStrip {
-  background: #111827;
+html[data-theme='dark'] .homeCardDescription {
+  color: #cbd5f5;
 }
 
-html[data-theme='dark'] .homeResourceItem {
-  background: #0f172a;
+html[data-theme='dark'] .homeCardScripture {
+  color: #94a3b8;
 }
 
 html[data-theme='dark'] .homeAbout {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,68 +1,35 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
+import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
 
 export default function Home() {
-  const [lastRead, setLastRead] = useState(null);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    const savedPath = window.localStorage.getItem('lastReadDocPath');
-    const savedTitle = window.localStorage.getItem('lastReadDocTitle');
-    if (savedPath) {
-      setLastRead({
-        path: savedPath,
-        title: savedTitle || '继续上次阅读',
-      });
-    }
-  }, []);
-
-  const articles = [
-    {
-      title: '在信心中持续前行',
-      excerpt: '从创世记到启示录，我们一步步学习信心的脚踪与盼望。',
-      meta: '更新于最近一次讲道',
-    },
-    {
-      title: '旧约中的恩典线索',
-      excerpt: '透过律法、历史与诗歌，看到神持守的救赎计划。',
-      meta: '旧约专题',
-    },
-    {
-      title: '福音光照日常',
-      excerpt: '灵修分享帮助我们在日常中操练祷告与顺服。',
-      meta: '灵修分享',
-    },
-  ];
-
-  const resources = [
-    {
-      title: '讲道资源',
-      description: '整理主日讲道与专题系列，按主题浏览。',
-    },
-    {
-      title: '阅读计划',
-      description: '按卷书阅读路径，帮助系统性阅读。',
-    },
-    {
-      title: '音频与讲义',
-      description: '收听与下载内容，随时继续学习。',
-    },
-  ];
+  const allDocsData = useAllDocsData();
+  const recentArticles = Object.values(allDocsData)
+    .flatMap((docData) => docData.versions)
+    .flatMap((version) => version.docs)
+    .map((doc) => {
+      const updatedAt = doc.frontMatter?.updated
+        ? Date.parse(doc.frontMatter.updated)
+        : doc.lastUpdatedAt || 0;
+      return {
+        permalink: doc.permalink,
+        cover: doc.frontMatter?.cover,
+        scripture: doc.frontMatter?.scripture,
+        title: doc.frontMatter?.sermonTitle || doc.title,
+        summary: doc.frontMatter?.summary || doc.description,
+        updatedAt,
+      };
+    })
+    .filter((article) => article.cover && article.scripture && article.summary)
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .slice(0, 3);
 
   return (
     <Layout title="圣经讲道与灵修分享" description="按卷书系统性分享神的话语与教会讲道">
       <main className="homeLayout">
         <section className="homeHero">
           <div className="homeHeroContent">
-            <div className="homeHeroTop">
-              <Link className="homeBackButton" to="/">
-                回到主页
-              </Link>
-              <span>按卷书阅读神的话语</span>
-            </div>
             <div>
               <h1>圣经讲道与灵修分享</h1>
               <p>
@@ -70,14 +37,9 @@ export default function Home() {
               </p>
             </div>
             <div className="homeHeroActions">
-              <Link className="button homePrimaryButton" to="/docs">
-                按卷书阅读神的话语
+              <Link className="button homePrimaryButton" to="/docs/old-testament/创世记/introduction">
+                从创世记开始阅读
               </Link>
-              {lastRead && (
-                <Link className="button homeSecondaryButton" to={lastRead.path}>
-                  继续上次阅读 · {lastRead.title}
-                </Link>
-              )}
             </div>
           </div>
         </section>
@@ -85,23 +47,14 @@ export default function Home() {
         <section className="homeSection">
           <h2>文章</h2>
           <div className="homeCardGrid">
-            {articles.map((article) => (
-              <div className="homeCard" key={article.title}>
-                <strong>{article.title}</strong>
-                <span className="homeCardMeta">{article.meta}</span>
-                <p>{article.excerpt}</p>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="homeSection">
-          <h2>资源</h2>
-          <div className="homeResourceStrip">
-            {resources.map((resource) => (
-              <div className="homeResourceItem" key={resource.title}>
-                <strong>{resource.title}</strong>
-                <p>{resource.description}</p>
+            {recentArticles.map((article) => (
+              <div className="homeCard" key={article.permalink}>
+                <Link className="homeCardLink" to={article.permalink}>
+                  <img className="homeCardImage" src={article.cover} alt={article.title} />
+                  <span className="homeCardScripture">{article.scripture}</span>
+                  <h3 className="homeCardTitle">{article.title}</h3>
+                  <p className="homeCardDescription">{article.summary}</p>
+                </Link>
               </div>
             ))}
           </div>


### PR DESCRIPTION
### Motivation
- 精简首页顶部区域，移除回到主页行与次要按钮，只保留一个主阅读按钮以符合新的视觉稿。 
- 文章区域改为展示最近更新的三篇讲道卡片，卡片包含封面图片、对应经文、讲道标题与简短描述以匹配示例图片。 
- 为让首页能自动读取并展示讲道卡片，文档目录需要在各卷书的 `introduction.md` 中加入封面与元数据字段。 

### Description
- 用 `useAllDocsData` 重写了 `src/pages/index.js` 的文章逻辑，移除原有的 `lastRead` 本地存储逻辑与资源区，并渲染最近三篇有 `cover`/`scripture`/`summary` 的文档卡片。 
- 调整并新增样式于 `src/css/custom.css`，为卡片增加 `homeCardLink`/`homeCardImage`/`homeCardScripture`/`homeCardTitle`/`homeCardDescription` 等类以支持图片与多行描述呈现。 
- 在 `public/img` 中新增三张示例封面 `sermon-light.svg`、`sermon-grace.svg`、`sermon-hope.svg` 以供卡片使用。 
- 更新了若干文档的前置属性（例如 `docs/old-testament/创世记/introduction.md`、`docs/new-testament/约翰福音/introduction.md`、`docs/new-testament/罗马书/introduction.md`），新增 `sermonTitle`、`scripture`、`summary`、`cover` 与 `updated` 字段以便被首页拾取。 

### Testing
- 运行 `npm run start` 尝试本地启动 Docusaurus，但启动过程因站点配置中的 `homepage`（`https://<GITHUB_USERNAME>.github.io`）被视为无效 URL 导致配置校验失败，启动未成功。 
- 尝试使用 Playwright 自动化脚本截图首页时因服务器未能启动而报 `net::ERR_CONNECTION_REFUSED`，截图未生成。 
- 仓库中未包含专门的单元测试或端到端测试，以上为本次对站点的自动化启动与截图尝试结果。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946af5413308323addf66f49bcefd74)