### PR TITLE
首页：恢复“继续上次阅读”、改进文章卡片并移除导航入口

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,14 +43,7 @@ const config = {
     ({
       navbar: {
         title: '圣经讲道与灵修分享',
-        items: [
-          {
-            type: 'docSidebar',
-            sidebarId: 'docsSidebar',
-            position: 'left',
-            label: '按卷书阅读神的话语',
-          },
-        ],
+        items: [],
       },
       docs: {
         sidebar: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -34,18 +34,27 @@ main {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  align-items: center;
+  text-align: center;
 }
 
 .homeHeroActions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
+  justify-content: center;
 }
 
 .homePrimaryButton {
   background: #d9f99d;
   color: #1f2937;
   border: none;
+}
+
+.homeSecondaryButton {
+  background: rgba(248, 250, 252, 0.22);
+  color: #f8fafc;
+  border: 1px solid rgba(248, 250, 252, 0.4);
 }
 
 .homeSection {
@@ -147,4 +156,10 @@ html[data-theme='dark'] .homeCardScripture {
 
 html[data-theme='dark'] .homeAbout {
   background: #0b0f1a;
+}
+
+html[data-theme='dark'] .homeSecondaryButton {
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.4);
+  color: #e2e8f0;
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
 
 export default function Home() {
   const allDocsData = useAllDocsData();
+  const defaultCover = '/img/sermon-light.svg';
   const recentArticles = Object.values(allDocsData)
     .flatMap((docData) => docData.versions)
     .flatMap((version) => version.docs)
@@ -14,14 +16,13 @@ export default function Home() {
         : doc.lastUpdatedAt || 0;
       return {
         permalink: doc.permalink,
-        cover: doc.frontMatter?.cover,
-        scripture: doc.frontMatter?.scripture,
+        cover: doc.frontMatter?.cover || defaultCover,
+        scripture: doc.frontMatter?.scripture || '圣经章节更新中',
         title: doc.frontMatter?.sermonTitle || doc.title,
-        summary: doc.frontMatter?.summary || doc.description,
+        summary: doc.frontMatter?.summary || doc.description || '讲道摘要更新中。',
         updatedAt,
       };
     })
-    .filter((article) => article.cover && article.scripture && article.summary)
     .sort((a, b) => b.updatedAt - a.updatedAt)
     .slice(0, 3);
 
@@ -40,6 +41,9 @@ export default function Home() {
               <Link className="button homePrimaryButton" to="/docs/old-testament/创世记/introduction">
                 从创世记开始阅读
               </Link>
+              <Link className="button homeSecondaryButton" to="/docs">
+                继续上次阅读
+              </Link>
             </div>
           </div>
         </section>
@@ -50,7 +54,11 @@ export default function Home() {
             {recentArticles.map((article) => (
               <div className="homeCard" key={article.permalink}>
                 <Link className="homeCardLink" to={article.permalink}>
-                  <img className="homeCardImage" src={article.cover} alt={article.title} />
+                  <img
+                    className="homeCardImage"
+                    src={useBaseUrl(article.cover)}
+                    alt={article.title}
+                  />
                   <span className="homeCardScripture">{article.scripture}</span>
                   <h3 className="homeCardTitle">{article.title}</h3>
                   <p className="homeCardDescription">{article.summary}</p>


### PR DESCRIPTION
### Motivation
- 恢复首页“继续上次阅读”入口，使首页仅保留按卷书阅读的两大入口以匹配设计要求。 
- 文章模块应显示最近更新的前三个 Markdown 文档，每个卡片包含封面图片、经文、标题与摘要，和提供的示例图一致。 
- 为避免因某些文章缺少元数据导致卡片不完整，需要补足缺省的图片/经文/摘要显示。 
- 调整 Hero 区域对齐与按钮样式以贴近示例图片的布局与视觉效果。 

### Description
- 在 `src/pages/index.js` 中：
  - 添加默认封面 `defaultCover` 与对 `scripture`/`summary` 的缺省值处理，保证即使缺少 frontMatter 也能渲染三张卡片。 
  - 从文章集合中按更新时间排序并截取最近三篇（`slice(0, 3)`），并将图片通过 `useBaseUrl` 加载以兼容站点基路径。 
  - 在 Hero 区域新增“继续上次阅读”按钮，指向 `/docs`（保留原有“从创世记开始阅读”按钮）。 
- 在 `src/css/custom.css` 中：
  - 调整 `.homeHeroContent` 对齐与文本居中，并新增 `.homeSecondaryButton` 样式以匹配示例按钮风格。 
- 在 `docusaurus.config.js` 中：
  - 移除导航栏中的 `docSidebar` 项，确保首页成为按卷书阅读的主要入口（只保留首页上的两个入口）。 

### Testing
- 运行 `npm run start` 尝试启动开发服务器，但因 `docusaurus.config.js` 中 `url` 使用占位符（`https://<GITHUB_USERNAME>.github.io`）被视为无效 URL 导致启动失败。（失败）
- 尝试使用 Playwright 访问本地页面并截图也因开发服务器未成功启动而无法连接，产生 `net::ERR_CONNECTION_REFUSED` 错误。 （失败）
- 已在代码中通过静态检查确认变更文件为 `src/pages/index.js`、`src/css/custom.css` 和 `docusaurus.config.js` 并提交。 
- 未运行其他自动化测试套件（项目中未提供或未配置可用的测试命令）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b3edd4808323934c5c83c16b5dcf)