### PR TITLE
优化首页：更新经文、恢复“继续上次阅读”并改进更新时间解析

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -34,15 +34,36 @@ main {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  align-items: center;
-  text-align: center;
+  align-items: flex-start;
+  text-align: left;
 }
 
 .homeHeroActions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  justify-content: center;
+  justify-content: flex-start;
+}
+
+.homeHeroVerse {
+  display: grid;
+  gap: 1.25rem;
+  max-width: 680px;
+  line-height: 1.8;
+}
+
+.homeHeroVerse h1,
+.homeHeroVerse h2 {
+  margin-bottom: 0.5rem;
+}
+
+.homeHeroVerse h2 {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.homeHeroVerse p {
+  margin: 0;
 }
 
 .homePrimaryButton {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -7,13 +7,28 @@ import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
 export default function Home() {
   const allDocsData = useAllDocsData();
   const defaultCover = '/img/sermon-light.svg';
+  const [lastReadPath, setLastReadPath] = useState('/docs');
+  const [lastReadTitle, setLastReadTitle] = useState('继续上次阅读');
+
+  const parseUpdatedAt = useMemo(() => {
+    return (value) => {
+      if (!value) {
+        return null;
+      }
+      if (value instanceof Date) {
+        return value.getTime();
+      }
+      const parsed = new Date(value).getTime();
+      return Number.isNaN(parsed) ? null : parsed;
+    };
+  }, []);
+
   const recentArticles = Object.values(allDocsData)
     .flatMap((docData) => docData.versions)
     .flatMap((version) => version.docs)
     .map((doc) => {
-      const updatedAt = doc.frontMatter?.updated
-        ? Date.parse(doc.frontMatter.updated)
-        : doc.lastUpdatedAt || 0;
+      const updatedAt =
+        parseUpdatedAt(doc.frontMatter?.updated) ?? doc.lastUpdatedAt ?? 0;
       return {
         permalink: doc.permalink,
         cover: doc.frontMatter?.cover || defaultCover,
@@ -26,23 +41,44 @@ export default function Home() {
     .sort((a, b) => b.updatedAt - a.updatedAt)
     .slice(0, 3);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const savedPath = window.localStorage.getItem('lastReadDocPath');
+    const savedTitle = window.localStorage.getItem('lastReadDocTitle');
+    if (savedPath) {
+      setLastReadPath(savedPath);
+    }
+    if (savedTitle) {
+      setLastReadTitle(`继续阅读：${savedTitle}`);
+    }
+  }, []);
+
   return (
     <Layout title="圣经讲道与灵修分享" description="按卷书系统性分享神的话语与教会讲道">
       <main className="homeLayout">
         <section className="homeHero">
           <div className="homeHeroContent">
-            <div>
-              <h1>圣经讲道与灵修分享</h1>
-              <p>
-                按卷书系统性分享神的话语与教会讲道，让每一次阅读成为敬拜与生命更新的起点。
-              </p>
+            <div className="homeHeroVerse">
+              <div>
+                <h1>约翰福音 1:1</h1>
+                <p>太初有道，道与　神同在，道就是　神。</p>
+              </div>
+              <div>
+                <h2>约翰福音 1:14</h2>
+                <p>
+                  道成了肉身，住在我们中间，满有恩典和真理。我们见过他的荣光，
+                  正是从父而来的独生子的荣光。
+                </p>
+              </div>
             </div>
             <div className="homeHeroActions">
               <Link className="button homePrimaryButton" to="/docs/old-testament/创世记/introduction">
                 从创世记开始阅读
               </Link>
-              <Link className="button homeSecondaryButton" to="/docs">
-                继续上次阅读
+              <Link className="button homeSecondaryButton" to={lastReadPath}>
+                {lastReadTitle}
               </Link>
             </div>
           </div>


### PR DESCRIPTION
### Motivation

- 修复文章排序和展示逻辑以确保使用 `frontMatter.updated` 的文档能正确进入最新文章列表。 
- 恢复并增强“继续上次阅读”功能，使按钮显示上次阅读的标题并跳转到保存的路径。 
- 按用户要求把首页主文案替换为约翰福音经文并改为左对齐以与页面整体布局协调。 

### Description

- 在 `src/pages/index.js` 中新增 `parseUpdatedAt` 并改为统一解析 `frontMatter.updated`，以修正更新时间排序逻辑。 
- 使用 `useEffect` 从 `localStorage` 读取 `lastReadDocPath` 与 `lastReadDocTitle` 并用状态 `lastReadPath` / `lastReadTitle` 更新首页按钮文本与链接。 
- 替换首页 Hero 文案为 `约翰福音 1:1` 与 `约翰福音 1:14`，并在组件中添加 `.homeHeroVerse` 的结构。 
- 在 `src/css/custom.css` 中将 Hero 区块改为左对齐（`align-items: flex-start; text-align: left; justify-content: flex-start`），并新增 `.homeHeroVerse` 样式以优化经文排版。 

### Testing

- 运行了开发服务器 `npm run start`，Docusaurus 客户端编译并启动成功。 
- 使用 Playwright 截图尝试访问页面时多次出现连接失败（`ERR_CONNECTION_REFUSED` / 名称解析错误），因此自动截图失败。 
- 使用 `curl` 请求首页路径返回 `HTTP/1.1 200 OK`，表示服务器能响应页面请求。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946be1b140c83238f9342eb1396ba0a)