### PR TITLE
完善首页文章展示并新增阅读页目录下拉框与布局优化

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -29,7 +29,7 @@ main {
 }
 
 .homeHeroContent {
-  max-width: 1080px;
+  max-width: 1200px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -79,7 +79,7 @@ main {
 }
 
 .homeSection {
-  max-width: 1080px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 3rem 1.5rem;
 }
@@ -91,7 +91,7 @@ main {
 
 .homeCardGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(3, minmax(240px, 1fr));
   gap: 1.5rem;
 }
 
@@ -103,6 +103,7 @@ main {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  min-height: 320px;
 }
 
 .homeCardLink {
@@ -137,6 +138,11 @@ main {
   margin: 0;
   color: #4b5563;
   line-height: 1.6;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .homeAbout {
@@ -146,10 +152,22 @@ main {
 }
 
 .homeAboutInner {
-  max-width: 1080px;
+  max-width: 1200px;
   margin: 0 auto;
   display: grid;
   gap: 1.5rem;
+}
+
+@media (max-width: 996px) {
+  .homeCardGrid {
+    grid-template-columns: repeat(2, minmax(220px, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .homeCardGrid {
+    grid-template-columns: 1fr;
+  }
 }
 
 html[data-theme='dark'] main,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,6 +23,17 @@ export default function Home() {
     };
   }, []);
 
+  const resolveSummary = useMemo(() => {
+    return (doc) => {
+      return (
+        doc.description ||
+        doc.frontMatter?.summary ||
+        doc.frontMatter?.description ||
+        '讲道摘要更新中。'
+      );
+    };
+  }, []);
+
   const recentArticles = Object.values(allDocsData)
     .flatMap((docData) => docData.versions)
     .flatMap((version) => version.docs)
@@ -34,7 +45,7 @@ export default function Home() {
         cover: doc.frontMatter?.cover || defaultCover,
         scripture: doc.frontMatter?.scripture || '圣经章节更新中',
         title: doc.frontMatter?.sermonTitle || doc.title,
-        summary: doc.frontMatter?.summary || doc.description || '讲道摘要更新中。',
+        summary: resolveSummary(doc),
         updatedAt,
       };
     })

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useWindowSize} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import DocItemPaginator from '@theme/DocItem/Paginator';
+import DocVersionBanner from '@theme/DocVersionBanner';
+import DocVersionBadge from '@theme/DocVersionBadge';
+import DocItemFooter from '@theme/DocItem/Footer';
+import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
+import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
+import DocItemTOCDropdown from '@theme/DocItem/TOCDropdown';
+import DocItemContent from '@theme/DocItem/Content';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import ContentVisibility from '@theme/ContentVisibility';
+import styles from './styles.module.css';
+
+function useDocTOC() {
+  const {frontMatter, toc} = useDoc();
+  const windowSize = useWindowSize();
+  const hidden = frontMatter.hide_table_of_contents;
+  const canRender = !hidden && toc.length > 0;
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+  const dropdown = canRender ? <DocItemTOCDropdown /> : undefined;
+  const desktop =
+    canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? (
+      <DocItemTOCDesktop />
+    ) : undefined;
+  return {
+    hidden,
+    mobile,
+    dropdown,
+    desktop,
+  };
+}
+
+export default function DocItemLayout({children}) {
+  const docTOC = useDocTOC();
+  const {metadata} = useDoc();
+  return (
+    <div className="row">
+      <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
+        <ContentVisibility metadata={metadata} />
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+            {docTOC.dropdown}
+            {docTOC.mobile}
+            <DocItemContent>{children}</DocItemContent>
+            <DocItemFooter />
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+    </div>
+  );
+}

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,10 @@
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}

--- a/src/theme/DocItem/TOCDropdown/index.js
+++ b/src/theme/DocItem/TOCDropdown/index.js
@@ -1,0 +1,120 @@
+import React, {useEffect, useMemo, useState} from 'react';
+import clsx from 'clsx';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import styles from './styles.module.css';
+
+function getNavbarHeight() {
+  const navbar = document.querySelector('.navbar');
+  return navbar ? navbar.clientHeight : 0;
+}
+
+function getActiveHeading(headings, anchorTopOffset) {
+  const nextVisibleHeading = headings.find((heading) => {
+    const rect = heading.getBoundingClientRect();
+    return rect.top >= anchorTopOffset;
+  });
+  if (nextVisibleHeading) {
+    const rect = nextVisibleHeading.getBoundingClientRect();
+    if (rect.top > 0 && rect.bottom < window.innerHeight / 2) {
+      return nextVisibleHeading;
+    }
+    const previousIndex = headings.indexOf(nextVisibleHeading) - 1;
+    return headings[previousIndex] || nextVisibleHeading;
+  }
+  return headings[headings.length - 1] || null;
+}
+
+export default function DocItemTOCDropdown({className}) {
+  const {toc, frontMatter} = useDoc();
+  const themeConfig = useThemeConfig();
+  const minHeadingLevel =
+    frontMatter.toc_min_heading_level ??
+    themeConfig.tableOfContents.minHeadingLevel;
+  const maxHeadingLevel =
+    frontMatter.toc_max_heading_level ??
+    themeConfig.tableOfContents.maxHeadingLevel;
+  const tocItems = useMemo(() => {
+    return toc.filter(
+      (item) =>
+        item.level >= minHeadingLevel && item.level <= maxHeadingLevel,
+    );
+  }, [toc, minHeadingLevel, maxHeadingLevel]);
+  const [activeId, setActiveId] = useState(tocItems[0]?.id ?? '');
+
+  useEffect(() => {
+    if (!tocItems.length) {
+      return undefined;
+    }
+    const headings = tocItems
+      .map((item) => document.getElementById(item.id))
+      .filter(Boolean);
+    const anchorTopOffset = themeConfig.navbar?.hideOnScroll
+      ? 0
+      : getNavbarHeight();
+
+    const updateActiveHeading = () => {
+      if (!headings.length) {
+        return;
+      }
+      const activeHeading = getActiveHeading(headings, anchorTopOffset);
+      if (activeHeading?.id) {
+        setActiveId(activeHeading.id);
+      }
+    };
+
+    updateActiveHeading();
+    document.addEventListener('scroll', updateActiveHeading);
+    window.addEventListener('resize', updateActiveHeading);
+    return () => {
+      document.removeEventListener('scroll', updateActiveHeading);
+      window.removeEventListener('resize', updateActiveHeading);
+    };
+  }, [themeConfig.navbar?.hideOnScroll, tocItems]);
+
+  useEffect(() => {
+    if (tocItems.length) {
+      setActiveId(tocItems[0]?.id ?? '');
+    }
+  }, [tocItems]);
+
+  const handleChange = (event) => {
+    const nextId = event.target.value;
+    setActiveId(nextId);
+    const heading = document.getElementById(nextId);
+    if (heading) {
+      heading.scrollIntoView({behavior: 'smooth', block: 'start'});
+    }
+    if (typeof window !== 'undefined') {
+      window.history.replaceState(null, '', `#${nextId}`);
+    }
+  };
+
+  if (!tocItems.length) {
+    return null;
+  }
+
+  return (
+    <div className={clsx(styles.dropdownWrapper, className)}>
+      <label className={styles.dropdownLabel} htmlFor="doc-toc-dropdown">
+        目录
+      </label>
+      <select
+        id="doc-toc-dropdown"
+        className={styles.dropdownSelect}
+        onChange={handleChange}
+        value={activeId}
+      >
+        {tocItems.map((item) => {
+          const indent = '—'.repeat(Math.max(item.level - minHeadingLevel, 0));
+          return (
+            <option key={item.id} value={item.id}>
+              {indent ? `${indent} ` : ''}
+              {item.value}
+            </option>
+          );
+        })}
+      </select>
+    </div>
+  );
+}

--- a/src/theme/DocItem/TOCDropdown/styles.module.css
+++ b/src/theme/DocItem/TOCDropdown/styles.module.css
@@ -1,0 +1,51 @@
+.dropdownWrapper {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin: 1rem 0 1.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+}
+
+.dropdownLabel {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.dropdownSelect {
+  flex: 1;
+  min-width: 220px;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  font-size: 0.95rem;
+  color: #111827;
+}
+
+.dropdownSelect:focus {
+  outline: none;
+  border-color: #94a3b8;
+  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.25);
+}
+
+:global(html[data-theme='dark']) .dropdownWrapper {
+  background: #0f172a;
+  border-color: rgba(148, 163, 184, 0.3);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
+}
+
+:global(html[data-theme='dark']) .dropdownLabel {
+  color: #e2e8f0;
+}
+
+:global(html[data-theme='dark']) .dropdownSelect {
+  background: rgba(15, 23, 42, 0.8);
+  color: #e2e8f0;
+  border-color: rgba(148, 163, 184, 0.35);
+}


### PR DESCRIPTION
### Motivation
- 让首页“文章”区域能显示最新文档的真实摘要内容，并使卡片显示更均匀饱满。  
- 在阅读页面增加一个目录下拉框，支持根据目录跳转到对应标题并能随页面滚动高亮。  
- 在不影响现有功能的前提下调整整体页面宽度与卡片网格以提升视觉均衡。  

### Description
- 在 `src/pages/index.js` 中新增 `resolveSummary`，改为优先显示文档正文 `description`，并回退到 `frontMatter.summary` 或默认文案以完善最近文章摘要的来源。  
- 新增 `src/theme/DocItem/TOCDropdown` 组件及样式，用于在阅读页顶部显示目录下拉框并实现滚动联动与平滑跳转（更新 URL hash）。  
- 覆盖文档布局 `src/theme/DocItem/Layout` 并在移动/小屏和桌面之间分别渲染下拉目录、移动 TOC 与桌面侧边 TOC，以统一交互体验。  
- 调整全局样式 `src/css/custom.css`，增大页面最大宽度、修改卡片网格为三栏（并添加响应式规则）、限制摘要行数并统一卡片最小高度以改善排版一致性。  

### Testing
- 运行 `npm run start` 启动开发服务器并成功编译（客户端编译成功）。  
- 使用 `curl` 请求首页根路径返回 `200 OK`，表示开发服务器在本地可访问。  
- 使用 Playwright 尝试生成页面截图以验证视觉变更时遇到 `net::ERR_CONNECTION_REFUSED` 导致截图失败。  
- 以上自动化验证中 `npm run start` 与 `curl` 成功，Playwright 截图尝试失败。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946cbea38f0832391f5e1758a751a93)