### PR TITLE
重构文章模块以显示约翰福音简介元数据

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,25 +11,14 @@ export default function Home() {
   const [lastReadTitle, setLastReadTitle] = useState('继续上次阅读');
 
   const extractIntroContent = useMemo(() => {
-    return (doc) => {
-      const quote =
-        doc.frontMatter?.quote ||
-        doc.frontMatter?.excerpt ||
-        doc.frontMatter?.verse ||
-        '';
-      const reflection =
-        doc.frontMatter?.reflection || doc.frontMatter?.meditation || '';
-      return {
-        scripture: doc.frontMatter?.scripture || '圣经章节更新中',
-        title: doc.frontMatter?.sermonTitle || doc.title,
-        summary:
-          reflection ||
-          doc.frontMatter?.summary ||
-          doc.description ||
-          '讲道摘要更新中。',
-        quote,
-      };
-    };
+    return (doc) => ({
+      scripture: doc.frontMatter?.scripture || '圣经章节更新中',
+      title: doc.frontMatter?.sermonTitle || doc.title,
+      summary:
+        doc.frontMatter?.summary ||
+        doc.description ||
+        '讲道摘要更新中。',
+    });
   }, []);
 
   const johnIntro = Object.values(allDocsData)
@@ -41,21 +30,9 @@ export default function Home() {
   const articleCards = introContent
     ? [
         {
-          key: 'scripture',
-          label: '圣经章节',
+          key: 'john-intro',
+          label: introContent.scripture,
           title: introContent.title,
-          description: introContent.scripture,
-        },
-        {
-          key: 'quote',
-          label: '经文摘录',
-          title: '经文摘录',
-          description: introContent.quote || '经文摘录更新中。',
-        },
-        {
-          key: 'reflection',
-          label: '默想与讲道示例',
-          title: '默想与讲道示例',
           description: introContent.summary,
         },
       ]


### PR DESCRIPTION
### Motivation

- 需要将文章模块展示的数据从约翰福音的 `introduction.md` 中读取并在首页卡片中显示。 
- 目标是把 `scripture` 对应为章节、`sermonTitle` 对应为讲道标题、`summary` 对应为简短介绍并直接映射到文章模块。 

### Description

- 修改 `extractIntroContent`，使其返回 `scripture`、`title`（来自 `sermonTitle`）和 `summary` 三项元数据。 
- 将文章卡片数据简化为单一卡片，`label` 使用 `introContent.scripture`，`title` 使用 `introContent.title`，`description` 使用 `introContent.summary`。 
- 变更文件：`src/pages/index.js`（精简并重映射文章模块内容）。 

### Testing

- 运行 `npm run start` 启动开发服务器，客户端编译成功（编译通过）。
- 使用 `curl -I http://127.0.0.1:3000/bible-sermons/` 检查站点响应，返回 `200 OK`（成功）。
- 使用 Playwright 生成页面截图的尝试因连接问题失败（Playwright 报 `ERR_CONNECTION_REFUSED`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d54b0d2c832388552582e3e69f4d)