### PR TITLE
移除首页文章模块并调整首页布局与关于我们样式

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -16,34 +16,40 @@ main {
 .homeLayout {
   background: #faf9f6;
   color: #1f2937;
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - var(--ifm-navbar-height, 0px));
 }
 
 .homeHero {
   position: relative;
-  min-height: 420px;
-  padding: 2.5rem 1.5rem 3rem;
+  min-height: 60vh;
+  padding: 2.5rem 1.5rem 3.5rem;
   background-image: url('../../public/img/home_hero.png');
   background-size: cover;
   background-position: center;
   color: #f8fafc;
+  display: flex;
 }
 
 .homeHeroContent {
-  max-width: 1200px;
+  max-width: 900px;
   margin: 0 auto;
+  width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  align-items: flex-start;
-  text-align: left;
-  padding-top: 1.5rem;
+  gap: 2rem;
+  align-items: center;
+  text-align: center;
+  justify-content: center;
+  padding: 1.5rem 1.5rem 3.5rem;
 }
 
 .homeHeroActions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  justify-content: flex-start;
+  justify-content: center;
 }
 
 .homeHeroVerse {
@@ -79,77 +85,11 @@ main {
   border: 1px solid rgba(248, 250, 252, 0.4);
 }
 
-.homeSection {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 3rem 1.5rem;
-}
-
-.homeSection h2 {
-  margin-bottom: 1.5rem;
-  font-size: 1.5rem;
-}
-
-.homeCardGrid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(240px, 1fr));
-  gap: 1.5rem;
-}
-
-.homeCard {
-  background: #ffffff;
-  border-radius: 16px;
-  padding: 1.25rem;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  min-height: 320px;
-}
-
-.homeCardLink {
-  color: inherit;
-  text-decoration: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  height: 100%;
-}
-
-.homeCardImage {
-  width: 100%;
-  height: 180px;
-  object-fit: cover;
-  border-radius: 12px;
-}
-
-.homeCardScripture {
-  font-size: 0.85rem;
-  color: #9ca3af;
-  letter-spacing: 0.02em;
-}
-
-.homeCardTitle {
-  font-size: 1.1rem;
-  margin: 0;
-  color: #111827;
-}
-
-.homeCardDescription {
-  margin: 0;
-  color: #4b5563;
-  line-height: 1.6;
-  flex: 1;
-  display: -webkit-box;
-  -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
 .homeAbout {
-  background: #111827;
+  background: #2b3648;
   color: #e5e7eb;
   padding: 3rem 1.5rem;
+  margin-top: auto;
 }
 
 .homeAboutInner {
@@ -159,43 +99,14 @@ main {
   gap: 1.5rem;
 }
 
-@media (max-width: 996px) {
-  .homeCardGrid {
-    grid-template-columns: repeat(2, minmax(220px, 1fr));
-  }
-}
-
-@media (max-width: 640px) {
-  .homeCardGrid {
-    grid-template-columns: 1fr;
-  }
-}
-
 html[data-theme='dark'] main,
 html[data-theme='dark'] .homeLayout {
   background: #0b0f1a;
   color: #e5e7eb;
 }
 
-html[data-theme='dark'] .homeCard {
-  background: #111827;
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
-}
-
-html[data-theme='dark'] .homeCardTitle {
-  color: #f8fafc;
-}
-
-html[data-theme='dark'] .homeCardDescription {
-  color: #cbd5f5;
-}
-
-html[data-theme='dark'] .homeCardScripture {
-  color: #94a3b8;
-}
-
 html[data-theme='dark'] .homeAbout {
-  background: #0b0f1a;
+  background: #1f2937;
 }
 
 html[data-theme='dark'] .homeSecondaryButton {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,42 +1,10 @@
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
-import useBaseUrl from '@docusaurus/useBaseUrl';
-import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
 
 export default function Home() {
-  const allDocsData = useAllDocsData();
-  const defaultCover = '/img/sermon-light.svg';
   const [lastReadPath, setLastReadPath] = useState('/docs');
   const [lastReadTitle, setLastReadTitle] = useState('继续上次阅读');
-
-  const extractIntroContent = useMemo(() => {
-    return (doc) => ({
-      scripture: doc.frontMatter?.scripture || '圣经章节更新中',
-      title: doc.frontMatter?.sermonTitle || doc.title,
-      summary:
-        doc.frontMatter?.summary ||
-        doc.description ||
-        '讲道摘要更新中。',
-    });
-  }, []);
-
-  const johnIntro = Object.values(allDocsData)
-    .flatMap((docData) => docData.versions)
-    .flatMap((version) => version.docs)
-    .find((doc) => doc.unversionedId === 'new-testament/约翰福音/introduction');
-
-  const introContent = johnIntro ? extractIntroContent(johnIntro) : null;
-  const articleCards = introContent
-    ? [
-        {
-          key: 'john-intro',
-          label: introContent.scripture,
-          title: introContent.title,
-          description: introContent.summary,
-        },
-      ]
-    : [];
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -73,29 +41,6 @@ export default function Home() {
                 {lastReadTitle}
               </Link>
             </div>
-          </div>
-        </section>
-
-        <section className="homeSection">
-          <h2>文章</h2>
-          <div className="homeCardGrid">
-            {articleCards.map((article) => (
-              <div className="homeCard" key={article.key}>
-                <Link
-                  className="homeCardLink"
-                  to={johnIntro?.permalink || '/docs/new-testament/约翰福音/introduction'}
-                >
-                  <img
-                    className="homeCardImage"
-                    src={useBaseUrl(johnIntro?.frontMatter?.cover || defaultCover)}
-                    alt={article.title}
-                  />
-                  <span className="homeCardScripture">{article.label}</span>
-                  <h3 className="homeCardTitle">{article.title}</h3>
-                  <p className="homeCardDescription">{article.description}</p>
-                </Link>
-              </div>
-            ))}
           </div>
         </section>
 


### PR DESCRIPTION
### Motivation

- 删除首页文章展示与相关数据逻辑以简化首页并避免冗余功能。
- 将首页经文（约翰福音 1:18）置于更靠上且响应式的居中位置以改善视觉布局。
- 底色调整为较浅的暗色调以提升“关于我们”区域可读性但仍保留暗色风格。
- 布局改为基于弹性盒（flex）和百分比/视窗高度的响应式设计以避免硬编码尺寸。

### Description

- 从 `src/pages/index.js` 中移除了文章卡片渲染部分及与之相关的 `useAllDocsData` / `useBaseUrl` / `useMemo` 等数据逻辑和导入。
- 更新 `src/css/custom.css` 将 `.homeLayout`、`.homeHero` 和 `.homeHeroContent` 改为响应式 flex 布局并使用 `min-height: 60vh` 与居中对齐以实现随窗口尺寸变化的布局效果。
- 删除了文章卡片相关的样式规则，并将 `.homeAbout` 的背景色从 `#111827` 改为 `#2b3648`（暗色但更柔和），暗色主题下改为 `#1f2937`，并用 `margin-top: auto` 使其贴近页面底部。
- 清理了不再使用的样式与导入，保留原有按钮与文字内容文本不变（保持约翰福音 1:18 文本和“关于我们”文案）。

### Testing

- 已使用 `npm run start` 启动 Docusaurus 开发服务器并观察客户端编译成功（编译成功）。
- 使用 `curl -I http://127.0.0.1:3000/bible-sermons/` 返回 `HTTP/1.1 200 OK`，确认页面可访问（成功）。
- 尝试使用 Playwright 截图页面失败，原因是浏览器容器无法连接到开发服务器（失败）。
- 已将修改加入版本控制并提交变更（`git commit` 成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d7a2d55483239b32de371d8654b5)