### PR TITLE
合并首页“关于我们”与页脚并调整布局

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -90,13 +90,26 @@ main {
   color: #e5e7eb;
   padding: 3rem 1.5rem;
   margin-top: auto;
+  flex: 1;
+  display: flex;
 }
 
 .homeAboutInner {
   max-width: 1200px;
   margin: 0 auto;
-  display: grid;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
+  flex: 1;
+}
+
+.homeFooter {
+  margin-top: auto;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(229, 231, 235, 0.35);
+  text-align: center;
+  font-size: 0.95rem;
 }
 
 html[data-theme='dark'] main,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,6 +52,7 @@ export default function Home() {
               在生活中经历主的恩典。
             </p>
             <p>如需联系或获取更多资源，请访问各卷书内容或相关资料区。</p>
+            <div className="homeFooter">© 2025 圣经讲道与灵修分享</div>
           </div>
         </section>
       </main>


### PR DESCRIPTION
### Motivation
- 将首页的“关于我们”与版权信息合并为一个下边栏区域，以便背景色与页脚视觉上连成整体。 
- 让关于/页脚区域撑满页面剩余高度，避免在没有图片覆盖时页面显得割裂。 
- 保持现有英雄区（经文、图片、按钮）不变，同时让下方区域固定在页面底部。 
- 简化布局结构以便于在不同视窗高度下一致展示底部信息。

### Description
- 在 `src/pages/index.js` 中将版权信息以 `<div className="homeFooter">© 2025 圣经讲道与灵修分享</div>` 添加到 `homeAboutInner` 内。 
- 在 `src/css/custom.css` 中将 `.homeAbout` 改为弹性容器（`flex: 1; display: flex;`）以填充剩余高度并与主区域连通。 
- 将 `.homeAboutInner` 从 grid 改为垂直 `flex` 布局并设为占满宽度与剩余高度（`width: 100%; display: flex; flex-direction: column; flex: 1;`）。 
- 新增 `.homeFooter` 样式以实现顶部边框、内边距和居中显示，且通过 `margin-top: auto` 固定在内容底部。

### Testing
- 运行了开发服务器：`npm run start`，客户端编译成功（Webpack 编译通过）。 
- 使用 `curl -I http://127.0.0.1:3000/bible-sermons/` 验证页面返回 `HTTP/1.1 200 OK`，访问正常。 
- 尝试使用 Playwright 生成页面截图的自动化检查，因浏览器连接问题导致截图任务失败。 
- 本次变更未包含单元测试或 CI 测试用例的运行。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946db0b7b148323a5bac47061642828)