### PR TITLE
调整首页主视觉与关于我们布局并移除重复版权文案

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -23,8 +23,8 @@ main {
 
 .homeHero {
   position: relative;
-  min-height: 60vh;
-  padding: 2.5rem 1.5rem 3.5rem;
+  min-height: 70vh;
+  padding: 3.5rem 1.5rem 4rem;
   background-image: url('../../public/img/home_hero.png');
   background-size: cover;
   background-position: center;
@@ -88,20 +88,18 @@ main {
 .homeAbout {
   background: #2b3648;
   color: #e5e7eb;
-  padding: 3rem 1.5rem;
-  margin-top: auto;
-  flex: 1;
+  padding: 2rem 1.5rem 2.5rem;
+  margin-top: 0;
   display: flex;
 }
 
 .homeAboutInner {
-  max-width: 1200px;
+  max-width: 900px;
   margin: 0 auto;
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  flex: 1;
+  gap: 1rem;
 }
 
 .homeFooter {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,7 +52,6 @@ export default function Home() {
               在生活中经历主的恩典。
             </p>
             <p>如需联系或获取更多资源，请访问各卷书内容或相关资料区。</p>
-            <div className="homeFooter">© 2025 圣经讲道与灵修分享</div>
           </div>
         </section>
       </main>


### PR DESCRIPTION
### Motivation
- 为了在不改变图片缩放方式的前提下，让首页主视觉区域展示更多背景图内容以增强视觉效果。 
- 减少“关于我们”区域的占用空间以提升页面布局美观度。 
- 修复页面上重复的版权文案，将页脚版权保留在全局配置处，避免重复显示。 

### Description
- 将首页主视觉区域 `.homeHero` 的 `min-height` 从 `60vh` 调整为 `70vh` 并增大 `padding`，以扩大背景图展示范围。 
- 缩小 `.homeAbout` 的内边距并移除 `margin-top: auto`，同时将 `.homeAboutInner` 的 `max-width` 从 `1200px` 降为 `900px` 并减小 `gap`，以减少该区占用。 
- 从 `src/pages/index.js` 中移除重复的 `<div className="homeFooter">© 2025 圣经讲道与灵修分享</div>`，保留全站配置中的版权输出。 

### Testing
- 启动开发服务器 `npm run start` 并进行构建，客户端编译成功。 
- 尝试使用 Playwright 截图以验证页面渲染，但访问本地开发服务器时返回 `ERR_CONNECTION_REFUSED`，因此未能生成截图。 
- 未运行额外的单元或集成测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946dcf527e483238ce14bc40f670b66)