### PR TITLE
优化首页“关于我们”与页脚的纵向占比与间距

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -30,6 +30,7 @@ main {
   background-position: center;
   color: #f8fafc;
   display: flex;
+  flex: 1 1 auto;
 }
 
 .homeHeroContent {
@@ -88,9 +89,13 @@ main {
 .homeAbout {
   background: #2b3648;
   color: #e5e7eb;
-  padding: 2rem 1.5rem 2.5rem;
+  padding: clamp(1.25rem, 2.4vh, 2rem) 1.5rem;
   margin-top: 0;
   display: flex;
+  flex: 0 1 18vh;
+  min-height: 15vh;
+  max-height: 20vh;
+  align-items: center;
 }
 
 .homeAboutInner {
@@ -100,6 +105,7 @@ main {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  text-align: center;
 }
 
 .homeFooter {
@@ -108,6 +114,11 @@ main {
   border-top: 1px solid rgba(229, 231, 235, 0.35);
   text-align: center;
   font-size: 0.95rem;
+}
+
+.footer {
+  padding-block: clamp(0.75rem, 1.8vh, 1.25rem);
+  font-size: 0.9rem;
 }
 
 html[data-theme='dark'] main,


### PR DESCRIPTION
### Motivation

- 将首页“关于我们”与页脚区域的垂直占比控制在 15%–20% 范围内以减少占用空间。
- 允许页面留白以保留简约美学，同时避免组件挤压主视觉区域。
- 使用响应式、非硬编码的样式以适配不同视口尺寸（使用 `flex` 与 `clamp` 等 CSS 特性）。
- 居中调整内容排列以改善视觉平衡。

### Description

- 为主视觉容器增加 `flex: 1 1 auto` 以使其在纵向上可伸缩并占据剩余空间（` .homeHero`）。
- 将 ` .homeAbout` 的内边距改为 `clamp(...)` 并通过 `flex: 0 1 18vh`、`min-height: 15vh`、`max-height: 20vh` 限制其高度以近似 15%–20% 的占比。
- 在 ` .homeAboutInner` 中添加 `text-align: center` 并在 ` .homeAbout` 上使用 `align-items: center` 以实现居中排列。
- 新增 `.footer` 的 `padding-block`（使用 `clamp`）与略小的 `font-size` 以收紧页脚占用空间。

### Testing

- 使用 `npm run start` 启动本地开发服并构建页面，客户端编译成功（`client compiled successfully`）。
- 试图使用 Playwright 截图页面时出现 `ERR_CONNECTION_REFUSED`，未能完成截图（网络/端口连接被拒绝）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946decffc58832391a46295808ab463)