### PR TITLE
将“关于我们”合并到深色页脚并调整样式

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -52,7 +52,7 @@ const config = {
         },
       },
       footer: {
-        style: 'light',
+        style: 'dark',
         copyright: `© ${new Date().getFullYear()} 圣经讲道与灵修分享`,
       },
       prism: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -86,53 +86,58 @@ main {
   border: 1px solid rgba(248, 250, 252, 0.4);
 }
 
-.homeAbout {
-  background: #2b3648;
-  color: #e5e7eb;
-  padding: clamp(1.25rem, 2.4vh, 2rem) 1.5rem;
-  margin-top: 0;
-  display: flex;
-  flex: 0 1 18vh;
-  min-height: 15vh;
-  max-height: 20vh;
-  align-items: center;
-}
-
-.homeAboutInner {
-  max-width: 900px;
-  margin: 0 auto;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  text-align: center;
-}
-
-.homeFooter {
-  margin-top: auto;
-  padding-top: 1.5rem;
-  border-top: 1px solid rgba(229, 231, 235, 0.35);
-  text-align: center;
-  font-size: 0.95rem;
-}
-
-.footer {
-  padding-block: clamp(0.75rem, 1.8vh, 1.25rem);
-  font-size: 0.9rem;
-}
-
 html[data-theme='dark'] main,
 html[data-theme='dark'] .homeLayout {
   background: #0b0f1a;
   color: #e5e7eb;
 }
 
-html[data-theme='dark'] .homeAbout {
-  background: #1f2937;
-}
-
 html[data-theme='dark'] .homeSecondaryButton {
   background: rgba(148, 163, 184, 0.12);
   border-color: rgba(148, 163, 184, 0.4);
   color: #e2e8f0;
+}
+
+.footer {
+  background: #1f2937;
+  color: #e5e7eb;
+  padding-block: clamp(1.25rem, 2.6vh, 2rem);
+  font-size: 0.95rem;
+}
+
+.footer__inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.footer__about {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.footer__about h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.footer__about p {
+  margin: 0;
+  line-height: 1.7;
+}
+
+.footer__divider {
+  width: 100%;
+  height: 1px;
+  background: rgba(229, 231, 235, 0.35);
+}
+
+.footer__copyright {
+  font-size: 0.9rem;
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -44,16 +44,6 @@ export default function Home() {
           </div>
         </section>
 
-        <section className="homeAbout">
-          <div className="homeAboutInner">
-            <h2>关于我们</h2>
-            <p>
-              我们致力于以圣经为中心的讲道与灵修分享，盼望帮助弟兄姊妹在真道上扎根，
-              在生活中经历主的恩典。
-            </p>
-            <p>如需联系或获取更多资源，请访问各卷书内容或相关资料区。</p>
-          </div>
-        </section>
       </main>
     </Layout>
   );

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import {useThemeConfig} from '@docusaurus/theme-common';
+
+export default function Footer() {
+  const {footer} = useThemeConfig();
+
+  return (
+    <footer className="footer footer--dark">
+      <div className="footer__inner">
+        <div className="footer__about">
+          <h2>关于我们</h2>
+          <p>
+            我们致力于以圣经为中心的讲道与灵修分享，盼望帮助弟兄姊妹在真道上扎根，
+            在生活中经历主的恩典。
+          </p>
+          <p>如需联系或获取更多资源，请访问各卷书内容或相关资料区。</p>
+        </div>
+        <div className="footer__divider" role="separator" />
+        {footer?.copyright ? (
+          <div className="footer__copyright">{footer.copyright}</div>
+        ) : null}
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
### Motivation
- 将首页占用较多的“关于我们”内容移入页脚以减少页面主体占比并实现居左对齐的页脚布局。
- 页脚应为暗色风格，且在“关于我们”和版权信息之间用分割线分隔以匹配设计要求。
- 需要一个可复用的自定义页脚组件以便于后续维护与样式调整。

### Description
- 从 `src/pages/index.js` 中移除了原有的 `homeAbout` 区块并新增自定义页脚组件 `src/theme/Footer/index.js` 来承载“关于我们”内容与版权信息。
- 在 `src/css/custom.css` 中添加并调整了页脚相关样式（暗色背景、左对齐、分割线、排版等），同时移除了原页面内的 about 样式。
- 将 Docusaurus 配置 `docusaurus.config.js` 中的 `footer.style` 改为 `dark` 以匹配新的页脚主题风格。

### Testing
- 运行了 `npm run start`（本地开发服务器），客户端编译成功（webpack 编译成功）。
- 使用 `curl -I http://127.0.0.1:3000/bible-sermons/` 验证返回 `HTTP/1.1 200 OK`，表示页面可访问。
- 尝试用 Playwright 截图以验证渲染，但多次尝试出现 `net::ERR_CONNECTION_REFUSED` 导致截图失败。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946e27502588323b23f7492daa61d9a)