### PR TITLE
调整首页经文区块的留白与布局

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -19,18 +19,24 @@ main {
   display: flex;
   flex-direction: column;
   min-height: calc(100vh - var(--ifm-navbar-height, 0px));
+  padding: clamp(2rem, 5vw, 3.5rem) 1.5rem clamp(3rem, 6vw, 4.5rem);
 }
 
 .homeHero {
   position: relative;
-  min-height: 70vh;
-  padding: 3.5rem 1.5rem 4rem;
+  min-height: clamp(420px, 55vh, 620px);
+  padding: clamp(2.5rem, 4vw, 3.5rem) clamp(1.5rem, 3vw, 3rem);
   background-image: url('../../public/img/home_hero.png');
   background-size: cover;
   background-position: center;
   color: #f8fafc;
   display: flex;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
 }
 
 .homeHeroContent {
@@ -43,7 +49,7 @@ main {
   align-items: center;
   text-align: center;
   justify-content: center;
-  padding: 1.5rem 1.5rem 3.5rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .homeHeroActions {


### PR DESCRIPTION
### Motivation

- 让首页的经文区块不再铺满整个屏幕以减轻视觉压迫感并保留与页脚之间的空隙。  
- 将经文区块处理为居中卡片式展示以提升视觉层次感。  
- 为不同屏幕尺寸使用响应式间距和高度控制以保持良好排版。  
- 满足页面美观与可读性的需求，同时保留背景图的视觉效果。

### Description

- 在 `src/css/custom.css` 中为 `.homeLayout` 增加上下内边距，使用 `padding: clamp(...)` 实现响应式留白。  
- 将 `.homeHero` 从满屏样式改为居中卡片式布局，调整为 `min-height: clamp(...)`、`padding: clamp(...)`、`width: min(1100px, 100%)`、`margin: 0 auto`、`border-radius: 28px`、`box-shadow`、并将 `flex` 改为 `0 0 auto`，同时启用 `overflow: hidden`。  
- 缩减 `.homeHeroContent` 的内边距为响应式 `padding: clamp(...)` 以确保区块内部与外部的空间感。  
- 仅涉及样式调整，没有改动页面结构或文本内容（变更文件为 `src/css/custom.css`）。

### Testing

- 启动开发服务器并运行 `npm run start`，客户端成功编译（编译成功信息已输出）。  
- 使用 `curl -I http://127.0.0.1:3000/bible-sermons/` 返回 `HTTP/1.1 200 OK`，表明服务器可访问。  
- 尝试使用 Playwright 截图脚本进行页面截图时发生连接错误（`ERR_CONNECTION_REFUSED`），截图未生成。  
- 未运行其他自动化或单元测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946e3ed6a4083239b8547485ab1e24b)