### PR TITLE
将首页经文改为全宽横幅布局，移除居中卡片样式

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -19,35 +19,35 @@ main {
   display: flex;
   flex-direction: column;
   min-height: calc(100vh - var(--ifm-navbar-height, 0px));
-  padding: clamp(2rem, 5vw, 3.5rem) 1.5rem clamp(3rem, 6vw, 4.5rem);
+  padding: 0;
 }
 
 .homeHero {
   position: relative;
-  min-height: clamp(420px, 55vh, 620px);
-  padding: clamp(2.5rem, 4vw, 3.5rem) clamp(1.5rem, 3vw, 3rem);
+  min-height: clamp(360px, 48vh, 520px);
+  padding: clamp(2.25rem, 4vw, 3.25rem) clamp(1.5rem, 4vw, 4rem);
   background-image: url('../../public/img/home_hero.png');
   background-size: cover;
   background-position: center;
   color: #f8fafc;
   display: flex;
   flex: 0 0 auto;
-  width: min(1100px, 100%);
-  margin: 0 auto;
-  border-radius: 28px;
+  width: 100%;
+  margin: 0;
+  border-radius: 0;
   overflow: hidden;
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+  box-shadow: none;
 }
 
 .homeHeroContent {
-  max-width: 900px;
-  margin: 0 auto;
+  max-width: 960px;
+  margin: 0;
   width: 100%;
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  align-items: center;
-  text-align: center;
+  align-items: flex-start;
+  text-align: left;
   justify-content: center;
   padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.5rem, 3vw, 2.5rem);
 }
@@ -56,13 +56,13 @@ main {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .homeHeroVerse {
   display: grid;
   gap: 1.25rem;
-  max-width: 680px;
+  max-width: 720px;
   line-height: 1.8;
 }
 


### PR DESCRIPTION
### Motivation
- 将首页经文与背景图从居中卡片式展示改为横幅布局以符合设计要求。 
- 减少页面外边距和阴影以尽量在单屏内显示内容，避免滚动。 
- 将文案与按钮左对齐以匹配横幅式视觉语言。 
- 保持背景图覆盖全宽以提高视觉连贯性。

### Description
- 编辑了 `src/css/custom.css`，将 `.homeLayout` 的外边距改为 `padding: 0` 以收紧页面。 
- 将 `.homeHero` 调整为 `width: 100%`、取消 `border-radius` 和 `box-shadow`，并微调 `min-height` 与 `padding` 使其更像横幅。 
- 将 `.homeHeroContent` 的 `max-width` 增至 `960px` 并改为左对齐（`align-items: flex-start` 和 `text-align: left`）。 
- 调整按钮容器 `.homeHeroActions` 为左对齐并将 `.homeHeroVerse` 的 `max-width` 设为 `720px` 以适应横幅布局。

### Testing
- 通过运行 `npm run start` 启动开发服务器，客户端成功编译（编译成功）。 
- 使用 `curl -I` 访问 `http://127.0.0.1:3000/bible-sermons/` 得到 `HTTP/1.1 200 OK`（成功）。 
- 尝试使用 `Playwright` 生成页面截图时连接被拒绝导致截图步骤失败（失败）。 
- 已提交修改并纳入版本控制（提交成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946e5a3fd608323a2287c957220a00c)