### PR TITLE
调整首页 hero 背景显示与经文位置样式

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,8 +27,9 @@ main {
   min-height: clamp(360px, 48vh, 520px);
   padding: clamp(2.25rem, 4vw, 3.25rem) clamp(1.5rem, 4vw, 4rem);
   background-image: url('../../public/img/home_hero.png');
-  background-size: cover;
-  background-position: center;
+  background-size: contain;
+  background-position: top center;
+  background-repeat: no-repeat;
   color: #f8fafc;
   display: flex;
   flex: 0 0 auto;
@@ -46,10 +47,10 @@ main {
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  align-items: flex-start;
-  text-align: left;
-  justify-content: center;
-  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.5rem, 3vw, 2.5rem);
+  align-items: center;
+  text-align: center;
+  justify-content: flex-start;
+  padding: clamp(1.25rem, 5vh, 3.5rem) clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .homeHeroActions {


### PR DESCRIPTION
### Motivation
- 让首页 hero 背景图完整显示且置顶居中以保留图片内容不被裁切。
- 将经文区块在 hero 中上方居中显示，提升视觉对齐与可读性。

### Description
- 将 `.homeHero` 的 `background-size` 从 `cover` 改为 `contain`，并设置 `background-position: top center` 与 `background-repeat: no-repeat`。
- 调整 `.homeHeroContent` 的对齐方式为 `align-items: center`、`text-align: center`、`justify-content: flex-start`，并更新 `padding` 值以将内容靠上显示。
- 修改文件：`src/css/custom.css`（样式调整，仅 CSS 变更）。

### Testing
- 通过运行 `npm run start` 启动开发服务器并构建，客户端成功编译（编译成功）。
- 使用 `curl -I http://localhost:3000/bible-sermons/` 返回 `HTTP/1.1 200 OK`，页面可访问。
- 尝试使用 Playwright 脚本截屏（`run_playwright_script`）以验证效果时遇到 `ERR_CONNECTION_REFUSED`，未能生成截图（失败）。
- 未运行任何单元测试或集成测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946e6d11554832392f12859cface1f8)