### PR TITLE
修复侧边栏空分类导致构建失败

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -112,12 +112,25 @@ const buildTestamentItems = (testamentDir) => {
   const bookOrder = BOOK_ORDER[testamentDir] || [];
   return bookOrder
     .filter((book) => fs.existsSync(path.join(DOCS_DIR, testamentDir, book)))
-    .map((book) => ({
-      type: 'category',
-      label: book,
-      collapsed: true,
-      items: getDocIdsForDir(path.posix.join(testamentDir, book)),
-    }));
+    .map((book) => {
+      const items = getDocIdsForDir(path.posix.join(testamentDir, book));
+      const category = {
+        type: 'category',
+        label: book,
+        collapsed: true,
+        items,
+      };
+
+      if (items.length === 0) {
+        category.link = {
+          type: 'generated-index',
+          title: book,
+          description: `${book} 暂无内容`,
+        };
+      }
+
+      return category;
+    });
 };
 
 module.exports = {
@@ -126,12 +139,22 @@ module.exports = {
       type: 'category',
       label: '旧约',
       collapsed: true,
+      link: {
+        type: 'generated-index',
+        title: '旧约',
+        description: '旧约暂时没有内容。',
+      },
       items: buildTestamentItems('old-testament'),
     },
     {
       type: 'category',
       label: '新约',
       collapsed: true,
+      link: {
+        type: 'generated-index',
+        title: '新约',
+        description: '新约暂时没有内容。',
+      },
       items: buildTestamentItems('new-testament'),
     },
   ],


### PR DESCRIPTION
### Motivation
- 修复当经卷文件夹存在但内部没有文档时，Docusaurus 在生成侧边栏时抛出“分类没有子项或链接”错误导致构建失败的问题。 
- 让空目录在站点中仍然可见且可访问，而不会影响其他侧边栏功能。 

### Description
- 在 `sidebars.js` 中的 `buildTestamentItems` 里，为每个经卷生成 `items` 后如果 `items.length === 0` 则为该分类添加 `link`，类型为 `generated-index`，并设置 `title` 和 `description`。 
- 为顶层的 `旧约` 和 `新约` 分类也添加了 `link`（`generated-index`），以保证当整个分支为空时仍有占位页面。 
- 相关改动集中在 `sidebars.js`，不改变已有文档的识别或排序逻辑，只在无子文档时提供占位链接。 

### Testing
- 未运行任何自动化测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947241b2dc883238f47e94cf2c06d44)