### PR TITLE
修复文档入口跳转与继续阅读按钮逻辑

### DIFF
--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -1,26 +1,56 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import Layout from '@theme/Layout';
-import useBaseUrl from '@docusaurus/useBaseUrl';
+import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
+
+const getDocsMetadata = (allDocsData) => {
+  const docDataEntries = Object.values(allDocsData || {});
+  if (docDataEntries.length === 0) {
+    return {firstDoc: null, permalinks: new Set()};
+  }
+
+  const {versions = []} = docDataEntries[0];
+  const [currentVersion] = versions;
+  const docs = currentVersion?.docs || [];
+  const permalinks = new Set(docs.map((doc) => doc.permalink));
+  return {firstDoc: docs[0] || null, permalinks};
+};
 
 export default function DocsIndex() {
-  const defaultDocPath = useBaseUrl('/docs/old-testament/创世记/introduction');
+  const allDocsData = useAllDocsData();
+  const {firstDoc, permalinks} = useMemo(
+    () => getDocsMetadata(allDocsData),
+    [allDocsData],
+  );
+  const [hasDocs, setHasDocs] = useState(true);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
       return;
     }
+
+    if (permalinks.size === 0) {
+      setHasDocs(false);
+      return;
+    }
+
     const savedPath = window.localStorage.getItem('lastReadDocPath');
-    if (savedPath) {
+    if (savedPath && permalinks.has(savedPath)) {
       window.location.replace(savedPath);
       return;
     }
-    window.location.replace(defaultDocPath);
-  }, [defaultDocPath]);
+
+    if (firstDoc?.permalink) {
+      window.location.replace(firstDoc.permalink);
+      return;
+    }
+
+    setHasDocs(false);
+  }, [firstDoc?.permalink, permalinks]);
 
   return (
-    <Layout title="正在跳转">
+    <Layout title={hasDocs ? '正在跳转' : '暂无内容'}>
       <main style={{padding: '4rem 1.5rem', textAlign: 'center'}}>
-        正在跳转到上次阅读的位置…
+        {hasDocs ? '正在跳转到可用的阅读内容…' : '暂无内容'}
       </main>
     </Layout>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,10 +1,30 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
+import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
+
+const getDocsMetadata = (allDocsData) => {
+  const docDataEntries = Object.values(allDocsData || {});
+  if (docDataEntries.length === 0) {
+    return {firstDoc: null, permalinks: new Set()};
+  }
+
+  const {versions = []} = docDataEntries[0];
+  const [currentVersion] = versions;
+  const docs = currentVersion?.docs || [];
+  const permalinks = new Set(docs.map((doc) => doc.permalink));
+  return {firstDoc: docs[0] || null, permalinks};
+};
 
 export default function Home() {
-  const [lastReadPath, setLastReadPath] = useState('/docs');
+  const allDocsData = useAllDocsData();
+  const {firstDoc, permalinks} = useMemo(
+    () => getDocsMetadata(allDocsData),
+    [allDocsData],
+  );
+  const [lastReadPath, setLastReadPath] = useState(null);
   const [lastReadTitle, setLastReadTitle] = useState('继续上次阅读');
+  const [hasLastRead, setHasLastRead] = useState(false);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -12,13 +32,17 @@ export default function Home() {
     }
     const savedPath = window.localStorage.getItem('lastReadDocPath');
     const savedTitle = window.localStorage.getItem('lastReadDocTitle');
-    if (savedPath) {
+    if (savedPath && permalinks.has(savedPath)) {
       setLastReadPath(savedPath);
+      setHasLastRead(true);
     }
     if (savedTitle) {
       setLastReadTitle(`继续阅读：${savedTitle}`);
     }
-  }, []);
+  }, [permalinks]);
+
+  const primaryPath = firstDoc?.permalink || '/docs';
+  const primaryLabel = firstDoc?.title ? `从${firstDoc.title}开始阅读` : '开始阅读';
 
   return (
     <Layout title="圣经讲道与灵修分享" description="按卷书系统性分享神的话语与教会讲道">
@@ -34,12 +58,14 @@ export default function Home() {
               </div>
             </div>
             <div className="homeHeroActions">
-              <Link className="button homePrimaryButton" to="/docs/old-testament/创世记/introduction">
-                从创世记开始阅读
+              <Link className="button homePrimaryButton" to={primaryPath}>
+                {primaryLabel}
               </Link>
-              <Link className="button homeSecondaryButton" to={lastReadPath}>
-                {lastReadTitle}
-              </Link>
+              {hasLastRead && lastReadPath ? (
+                <Link className="button homeSecondaryButton" to={lastReadPath}>
+                  {lastReadTitle}
+                </Link>
+              ) : null}
             </div>
           </div>
         </section>


### PR DESCRIPTION
### Motivation
- 修复首页和文档入口对默认创世纪路径的硬编码，因为当对应目录不存在时会导致 Docusaurus 报错并阻塞构建。  
- 在文档集合为空或目标文档不可达时，需要向用户展示“暂无内容”而不是跳转到不存在的路径。  
- 当用户没有上次阅读记录（首次访问或浏览器记录被清空）时，不应显示“继续阅读”按钮以免产生无效链接。  

### Description
- 用 `useAllDocsData` 加 `getDocsMetadata` 的方式替换硬编码默认路径以动态获取首个文档和所有 `permalink`。  
- 在 `src/pages/docs/index.js` 中实现：优先跳转到本地保存且存在于 `permalinks` 的路径，若无则跳转到首个可用文档，若整个文档集为空则显示 `暂无内容`。  
- 在 `src/pages/index.js` 中实现：根据首个文档计算主入口 `primaryPath` 与 `primaryLabel`，并仅当 `localStorage` 中的 `lastReadDocPath` 存在且在 `permalinks` 中时才显示“继续阅读”按钮。  
- 新增和调整的状态包括 `hasDocs` 与 `hasLastRead`，并移除原先对创世记路径的硬编码引用。  

### Testing
- 未运行任何自动化测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947266e8d708323bbb931f6c01ea024)